### PR TITLE
Remove use of the slow bitlength32 and bitlength64 functions

### DIFF
--- a/ibm2ieee/_ibm2ieee.c
+++ b/ibm2ieee/_ibm2ieee.c
@@ -170,7 +170,7 @@ ibm64ieee32(npy_uint64 ibm)
 
     if (ieee_expt >= 0 && ieee_expt < IEEE32_MAXEXP) {
         /* normal case; shift right 32, with round-ties-to-even */
-        npy_uint32 round_up = (ibm_frac & (npy_uint64)(0x17fffffff)) > 0;
+        npy_uint32 round_up = (ibm_frac & (npy_uint64)(0x17fffffff)) > 0U;
         ieee_frac = ((ibm_frac >> 31) + round_up) >> 1;
         return ieee_sign + ((npy_uint32)ieee_expt << 23) + ieee_frac;
     }


### PR DESCRIPTION
This PR significantly improves performance of the `ibm2float32` and `ibm2float64` functions by eliminating the use of the slow, branchy, `bitlength32` and `bitlength64` functions. Times for common cases are comparable with those given by use of `__builtin_clz` to count bits.

Profiling `ibm2float32` for 32-bit input with the script given in #3, on master I get:
```
[0.21992336, 0.22001238700000003, 0.21952936199999995, 0.22023687200000008, 0.22033622500000005]
```
on this branch I get:
```
[0.040951373999999985, 0.04094095000000003, 0.04472522999999995, 0.04151574299999994, 0.04090724899999998]
```
and on the `clz-version` branch that uses the clang builtins, I get:
```
[0.040852551999999986, 0.042458280000000015, 0.04042625299999991, 0.039997842000000006, 0.03994737600000009]
```





Closes #3.