### PR TITLE
CI and packaging updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - 2.7
   - 3.5
   - 3.6
+os:
+  - linux
+  - osx
 install:
   - pip install -e ".[test]"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python:
   - 2.7
   - 3.5
   - 3.6
-os:
-  - linux
-  - osx
 install:
   - pip install -e ".[test]"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 3.5
   - 3.6
 install:
-  - pip install -r requirements.txt
-  - pip install .
+  - pip install -e ".[test]"
 script:
-  - mkdir tmp && cd tmp && python -m unittest discover -v ibm2ieee
+  - python -m unittest discover -v ibm2ieee

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,18 @@
 Changelog for ibm2ieee
 ======================
 
+Release 1.0.1
+-------------
+
+Release date: 2018-12-04
+
+Bugfix release, fixing another distribution issue.
+
+- Add pyproject.toml file encapsulating build requirements. With this, a
+  ``pip install ibm2ieee`` should automatically download NumPy before
+  running the setup script. (PR #7)
+
+
 Release 1.0.0
 -------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ Release date: 2018-12-04
 
 Bugfix release, fixing another distribution issue.
 
-- Add pyproject.toml file encapsulating build requirements. With this, a
+- Add ``pyproject.toml`` file encapsulating build requirements. With this, a
   ``pip install ibm2ieee`` should automatically download NumPy before
   running the setup script. (PR #7)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.rst
 include LICENSE
 include MANIFEST.in
 include CHANGES
+include pyproject.toml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,7 @@ environment:
     - PYTHON: "C:\\Python36-x64"
 
 install:
-  - pip install -r requirements.txt
-  - pip install -e .
+  - pip install -e ".[test]"
 
 build: off
 

--- a/ibm2ieee/version.py
+++ b/ibm2ieee/version.py
@@ -4,4 +4,4 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Version string.
-version = "1.0.0"
+version = "1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["numpy", "setuptools", "wheel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-numpy
-packaging

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ if __name__ == "__main__":
         long_description_content_type="text/x-rst",
         keywords="ibm hfp ieee754 hexadecimal floating-point ufunc",
         install_requires=["numpy"],
+        extras_require={
+            "test": ["packaging"],
+        },
         packages=setuptools.find_packages(),
         ext_modules=[ibm2ieee_extension],
         classifiers=[


### PR DESCRIPTION
A few CI and packaging updates:

- include a `pyproject.toml` file (see [PEP 518](https://www.python.org/dev/peps/pep-0518/)), so that we can declare `numpy` as a build-time dependency. In theory, this should mean that a `pip install ibm2ieee` installs `numpy` before building.
- remove `requirements.txt` in favour of specifying the test dependencies via `extras_require`
- make corresponding changes in CI config files

Also bumps the version number and changelog in preparation for a 1.0.1 release.