### PR TITLE
Test on Python 3.7 and 3.8, and update classifiers for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
   - 3.7
   - 3.8
 install:
-  - pip install --no-build-isolation -e ".[test]"
+  - pip install -e ".[test]"
 script:
   - python -m unittest discover -v ibm2ieee

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
   - 3.7
   - 3.8
 install:
-  - pip install -e ".[test]"
+  - pip install --no-build-isolation -e ".[test]"
 script:
   - python -m unittest discover -v ibm2ieee

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 install:
   - pip install -e ".[test]"
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,13 @@ environment:
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
   - pip install -e ".[test]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["numpy", "setuptools", "wheel"]
+requires = ["numpy==1.14.5", "setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,9 @@ if __name__ == "__main__":
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
         keywords="ibm hfp ieee754 hexadecimal floating-point ufunc",
-        install_requires=["numpy"],
+        # Minimum NumPy version chosen to match the current minimum
+        # for SciPy. NumPy 1.13.x doesn't build cleanly on Python 3.8.
+        install_requires=["numpy>=1.14.5"],
         extras_require={
             "test": ["packaging"],
         },

--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,6 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
         ],
     )


### PR DESCRIPTION
Run Travis CI tests on Python 3.7 and 3.8, and update classifiers to make it clear 3.8 is supported.

EDIT: Also changes the way that the NumPy version is selected. See discussion in #10.

Closes #9.