### PR TITLE
Use pkg_resources instead of packaging for version tests

### DIFF
--- a/ibm2ieee/test/test_version.py
+++ b/ibm2ieee/test/test_version.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import unittest
 
-import packaging.version
+import pkg_resources
 import six
 
 import ibm2ieee.version
@@ -17,7 +17,7 @@ class TestVersion(unittest.TestCase):
         self.assertIsInstance(version, six.text_type)
 
         # Check that version number is normalised and complies with PEP 440.
-        version_object = packaging.version.Version(version)
+        version_object = pkg_resources.parse_version(version)
         self.assertEqual(six.text_type(version_object), version)
 
     def test_top_level_package_version(self):

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         # for SciPy. NumPy 1.13.x doesn't build cleanly on Python 3.8.
         install_requires=["numpy>=1.14.5"],
         extras_require={
-            "test": ["packaging"],
+            "test": ["setuptools", "six"],
         },
         packages=setuptools.find_packages(),
         ext_modules=[ibm2ieee_extension],


### PR DESCRIPTION
This simplifies the test dependencies a bit, requiring `setuptools` (which is very likely to be already installed) rather than `packaging` (which isn't, and which has other dependencies that we don't really need here).