### PR TITLE
Use the correct Python interpreter in Appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
     - PYTHON: "C:\\Python38-x64"
 
 install:
-  - %PYTHON%\\python.exe -m pip install -e ".[test]"
+  - "%PYTHON%\\python.exe -m pip install -e .[test]"
 
 build: off
 
 test_script:
-  - %PYTHON%\\python.exe -m unittest discover -v
+  - "%PYTHON%\\python.exe -m unittest discover -v"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
     - PYTHON: "C:\\Python38-x64"
 
 install:
-  - pip install -e ".[test]"
+  - %PYTHON%\\python.exe -m pip install -e ".[test]"
 
 build: off
 
 test_script:
-  - python -m unittest discover -v .
+  - %PYTHON%\\python.exe -m unittest discover -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
     - PYTHON: "C:\\Python38-x64"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install -e .[test]"
+  - "%PYTHON%/python.exe -m pip install -e .[test]"
 
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe -m unittest discover -v"
+  - "%PYTHON%/python.exe -m unittest discover -v"


### PR DESCRIPTION
This PR attempts to fix an embarrassing Appveyor config error: we were testing against the system Python (Python 2.7) 10 times over, instead of testing against the target Python version. 