### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 install:
   - pip install -e ".[test]"
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,13 @@ environment:
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python39"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python39-x64"
 
 install:
   - "%PYTHON%/python.exe -m pip install -e .[test]"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2019
+
 environment:
   matrix:
     - PYTHON: "C:\\Python27"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,11 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python39"
-    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "numpy>=1.14,<1.15; python_version<'3.9'",
     "numpy>=1.16,<1.17; python_version=='3.9'",
     # don't pin version for as-yet-unreleased versions of Python
-    "numpy; python_version>'3.9'",
+    "numpy>=1.16; python_version>'3.9'",
     "setuptools",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,12 @@
 [build-system]
-requires = ["numpy==1.14.5", "setuptools", "wheel"]
+requires = [
+    # pin NumPy version used in the build, to avoid building against the latest
+    # NumPy from PyPI (and potentially introducing ABI compatibilities with the
+    # actual NumPy version in the environment)
+    "numpy>=1.14,<1.15; python_version<'3.9'",
+    "numpy>=1.16,<1.17; python_version=='3.9'",
+    # don't pin version for as-yet-unreleased versions of Python
+    "numpy; python_version>'3.9'",
+    "setuptools",
+    "wheel",
+]

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,10 @@ if __name__ == "__main__":
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
         keywords="ibm hfp ieee754 hexadecimal floating-point ufunc",
-        # Minimum NumPy version chosen to match the current minimum
-        # for SciPy. NumPy 1.13.x doesn't build cleanly on Python 3.8.
-        install_requires=["numpy>=1.14.5"],
+        install_requires=[
+            "numpy>=1.14; python_version<'3.9'",
+            "numpy>=1.16; python_version>='3.9'",
+        ],
         extras_require={
             "test": ["setuptools", "six"],
         },
@@ -72,5 +73,6 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
         ],
     )


### PR DESCRIPTION
This PR updates the packaging to explicitly support Python 3.9, and tweaks the `pyproject.toml` configuration

- Add 3.9 trove classifier in `setup.py`
- Add builds on Python 3.9 for Travis CI and Appveyor
- Build against NumPy 1.16.x for Python 3.9.x.
- Don't pin the NumPy version for as-yet unreleased Python versions

Closes #16
