### PR TITLE
Drop support for outdated Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,8 @@ usual way::
 Note that it includes a C extension, so you'll need a compiler on your system
 to be able to install.
 
+ibm2ieee requires Python >= 3.6.
+
 
 License
 -------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,9 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,8 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"

--- a/ibm2ieee/__init__.py
+++ b/ibm2ieee/__init__.py
@@ -1,10 +1,6 @@
 # Copyright (c) 2018, Enthought, Inc.
 # All rights reserved.
 
-# Not importing Unicode literals, because the elements of __all__
-# need to be bytestrings in Python 2.
-from __future__ import absolute_import, print_function
-
 from .version import version as __version__
 from ._ibm2ieee import ibm2float32, ibm2float64
 

--- a/ibm2ieee/test/test_ibm2ieee.py
+++ b/ibm2ieee/test/test_ibm2ieee.py
@@ -1,14 +1,12 @@
 # Copyright (c) 2018, Enthought, Inc.
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import contextlib
 from fractions import Fraction as F
+import io
 import unittest
 
 import numpy as np
-import six
 
 from ibm2ieee import ibm2float32, ibm2float64
 
@@ -28,18 +26,6 @@ IEEE64_SIGN = 0x8000000000000000
 
 
 # Simple and inefficient Python conversions, for testing purposes.
-
-def round_ties_to_even(f):
-    """
-    Round a Fraction to the nearest integer, rounding ties to even.
-    """
-    if six.PY2:
-        q, r = divmod(f, 1)
-        round_up = 2 * r > 1 or (2 * r == 1 and q % 2 == 1)
-        return q + round_up
-    else:
-        return round(f)
-
 
 def ilog2_fraction(f):
     """
@@ -93,7 +79,7 @@ def ieee32_from_fraction(s, f):
     if not f:
         return s
     exponent = max(ilog2_fraction(f), IEEE32_MINEXP)
-    ieee_frac = round_ties_to_even(f / TWO**(exponent - IEEE32_FRAC))
+    ieee_frac = round(f / TWO**(exponent - IEEE32_FRAC))
     expt_and_frac = ((exponent - IEEE32_MINEXP) << IEEE32_FRAC) + ieee_frac
     return min(expt_and_frac, IEEE32_POSINF) + s
 
@@ -106,7 +92,7 @@ def ieee64_from_fraction(s, f):
     if not f:
         return s
     exponent = max(ilog2_fraction(f), IEEE64_MINEXP)
-    ieee_frac = round_ties_to_even(f / TWO**(exponent - IEEE64_FRAC))
+    ieee_frac = round(f / TWO**(exponent - IEEE64_FRAC))
     expt_and_frac = ((exponent - IEEE64_MINEXP) << IEEE64_FRAC) + ieee_frac
     return min(expt_and_frac, IEEE64_POSINF) + s
 
@@ -487,12 +473,12 @@ class TestIBM2IEEE(unittest.TestCase):
         self.assertIn("__version__", locals)
 
     def test_np_info(self):
-        output = six.moves.StringIO()
+        output = io.StringIO()
         with contextlib.closing(output):
             np.info(ibm2float32, output=output)
             self.assertIn("Examples", output.getvalue())
 
-        output = six.moves.StringIO()
+        output = io.StringIO()
         with contextlib.closing(output):
             np.info(ibm2float64, output=output)
             self.assertIn("Examples", output.getvalue())

--- a/ibm2ieee/test/test_version.py
+++ b/ibm2ieee/test/test_version.py
@@ -1,12 +1,9 @@
 # Copyright (c) 2018, Enthought, Inc.
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import unittest
 
 import pkg_resources
-import six
 
 import ibm2ieee.version
 
@@ -14,11 +11,11 @@ import ibm2ieee.version
 class TestVersion(unittest.TestCase):
     def test_version_string(self):
         version = ibm2ieee.version.version
-        self.assertIsInstance(version, six.text_type)
+        self.assertIsInstance(version, str)
 
         # Check that version number is normalised and complies with PEP 440.
         version_object = pkg_resources.parse_version(version)
-        self.assertEqual(six.text_type(version_object), version)
+        self.assertEqual(str(version_object), version)
 
     def test_top_level_package_version(self):
         self.assertEqual(

--- a/ibm2ieee/version.py
+++ b/ibm2ieee/version.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2018, Enthought, Inc.
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 # Version string.
 version = "1.0.2"

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ if __name__ == "__main__":
             "Intended Audience :: Developers",
             "License :: OSI Approved :: BSD License",
             "Operating System :: OS Independent",
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018, Enthought, Inc.
 # All rights reserved.
 
-import io
 import os
 
 import numpy
@@ -12,7 +11,7 @@ def get_version_info():
     """ Extract version information as a dictionary from version.py. """
     version_info = {}
     version_filename = os.path.join("ibm2ieee", "version.py")
-    with io.open(version_filename, "r", encoding="utf-8") as version_module:
+    with open(version_filename, "r", encoding="utf-8") as version_module:
         version_code = compile(version_module.read(), "version.py", "exec")
         exec(version_code, version_info)
     return version_info
@@ -20,7 +19,7 @@ def get_version_info():
 
 def get_long_description():
     """ Read long description from README.txt. """
-    with io.open("README.rst", "r", encoding="utf-8") as readme:
+    with open("README.rst", "r", encoding="utf-8") as readme:
         return readme.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
         extras_require={
             "test": ["setuptools"],
         },
+        python_requires=">=3.6",
         packages=setuptools.find_packages(),
         ext_modules=[ibm2ieee_extension],
         classifiers=[
@@ -65,7 +66,6 @@ if __name__ == "__main__":
             "License :: OSI Approved :: BSD License",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2018, Enthought, Inc.
 # All rights reserved.
-from __future__ import absolute_import, print_function
 
 import io
 import os
@@ -36,7 +35,7 @@ ibm2ieee_extension = setuptools.Extension(
     include_dirs=[numpy.get_include()],
 )
 
-SHORT_DESCRIPTION = u"""\
+SHORT_DESCRIPTION = """\
 Convert IBM hexadecimal floating-point data to IEEE 754 floating-point data.
 """.rstrip()
 
@@ -56,7 +55,7 @@ if __name__ == "__main__":
         # for SciPy. NumPy 1.13.x doesn't build cleanly on Python 3.8.
         install_requires=["numpy>=1.14.5"],
         extras_require={
-            "test": ["setuptools", "six"],
+            "test": ["setuptools"],
         },
         packages=setuptools.find_packages(),
         ext_modules=[ibm2ieee_extension],


### PR DESCRIPTION
This PR

- Drops support for Python 2.7 and Python 3.5
- Cleans up Python 2 compatibility code, and removes `six` as a dependency for the test suite.