### PR TITLE
Update copyright headers, and check them in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - 3.9
 install:
   - python -m pip install --upgrade pip setuptools wheel
-  - python -m pip install -e ".[test]"
   - python -m pip install flake8 flake8-ets
+  - python -m pip install -e ".[test]"
 script:
   - python -m flake8
   - python -m unittest discover -v ibm2ieee

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - 3.7
   - 3.8
 install:
-  - pip install -e ".[test]"
+  - python -m pip install --upgrade pip setuptools wheel
+  - python -m pip install -e ".[test]"
+  - python -m pip install flake8 flake8-ets
 script:
+  - python -m flake8
   - python -m unittest discover -v ibm2ieee

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, Enthought, Inc.
+(C) Copyright 2018-2021 Enthought, Inc., Austin, TX
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.rst
-include LICENSE
+include LICENSE.txt
 include MANIFEST.in
 include CHANGES
 include pyproject.toml

--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,12 @@ to be able to install.
 License
 -------
 
-The ibm2ieee package is copyright (c) 2018, Enthought, Inc.
+(C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+All rights reserved.
 
-The ibm2ieee package is licensed under a standard BSD 3-clause License. See the
-LICENSE file for details.
+This software is provided without warranty under the terms of the BSD
+license included in LICENSE.txt and may be redistributed only under
+the conditions described in the aforementioned license. The license
+is also available online at http://www.enthought.com/licenses/BSD.txt
+
+Thanks for using Enthought open source!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,12 @@ environment:
     - PYTHON: "C:\\Python39-x64"
 
 install:
+  - "%PYTHON%/python.exe -m pip install --upgrade pip setuptools wheel"
+  - "%PYTHON%/python.exe -m pip install flake8 flake8-ets"
   - "%PYTHON%/python.exe -m pip install -e .[test]"
 
 build: off
 
 test_script:
+  - "%PYTHON%/python.exe -m flake8"
   - "%PYTHON%/python.exe -m unittest discover -v"

--- a/ibm2ieee/__init__.py
+++ b/ibm2ieee/__init__.py
@@ -1,5 +1,12 @@
-# Copyright (c) 2018, Enthought, Inc.
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 
 # Not importing Unicode literals, because the elements of __all__
 # need to be bytestrings in Python 2.

--- a/ibm2ieee/_ibm2ieee.c
+++ b/ibm2ieee/_ibm2ieee.c
@@ -1,7 +1,12 @@
-/*
-Copyright (c) 2018, Enthought, Inc.
-All rights reserved.
-*/
+// (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+// All rights reserved.
+//
+// This software is provided without warranty under the terms of the BSD
+// license included in LICENSE.txt and may be redistributed only under
+// the conditions described in the aforementioned license. The license
+// is also available online at http://www.enthought.com/licenses/BSD.txt
+//
+// Thanks for using Enthought open source!
 
 #include "Python.h"
 #include "numpy/ndarraytypes.h"

--- a/ibm2ieee/test/__init__.py
+++ b/ibm2ieee/test/__init__.py
@@ -1,2 +1,9 @@
-# Copyright (c) 2018, Enthought, Inc.
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/ibm2ieee/test/test_ibm2ieee.py
+++ b/ibm2ieee/test/test_ibm2ieee.py
@@ -1,5 +1,12 @@
-# Copyright (c) 2018, Enthought, Inc.
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 
 from __future__ import absolute_import, print_function, unicode_literals
 

--- a/ibm2ieee/test/test_version.py
+++ b/ibm2ieee/test/test_version.py
@@ -1,5 +1,12 @@
-# Copyright (c) 2018, Enthought, Inc.
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 
 from __future__ import absolute_import, print_function, unicode_literals
 

--- a/ibm2ieee/version.py
+++ b/ibm2ieee/version.py
@@ -1,5 +1,12 @@
-# Copyright (c) 2018, Enthought, Inc.
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 
 from __future__ import absolute_import, print_function, unicode_literals
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
-# Copyright (c) 2018, Enthought, Inc.
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from __future__ import absolute_import, print_function
 
 import io


### PR DESCRIPTION
This PR:
- updates the copyright end year to 2021
- replaces the currently copyright headers with the full form used elsewhere (e.g., in ETS)
- adds a flake8 check to the Travis CI configuration to validate the presence and correctness of the headers
- renames the LICENSE file to LICENSE.txt (and updates MANIFEST.in accordingly)