### PR TITLE
Add workflow to test PyPI wheels

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 jobs:
-  test-wheel:
+  test-pypi-wheel:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -38,7 +38,7 @@ jobs:
         python -m unittest discover -v ibm2ieee
 
 jobs:
-  test-sdist:
+  test-pypi-sdist:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -28,8 +28,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install wheel
-    - name: Install the package
-        python -m pip install ibm2ieee
+    - name: Install wheel from PyPI
+      run: |
+        python -m pip install --only-binary ibm2ieee
     - name: Run tests in a clean directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -37,7 +37,6 @@ jobs:
         cd testdir
         python -m unittest discover -v ibm2ieee
 
-jobs:
   test-pypi-sdist:
     strategy:
       matrix:

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -1,7 +1,9 @@
 name: Test installation from PyPI
 
 on:
-  pull_request
+  schedule:
+    # Run at 02:37 UTC on the 11th and 25th of every month
+    - cron: '37 2 11,25 * *'
 
 jobs:
   test-pypi-wheel:

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 jobs:
-  test:
+  test-wheel:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -31,6 +31,40 @@ jobs:
     - name: Install wheel from PyPI
       run: |
         python -m pip install --only-binary :all: ibm2ieee
+    - name: Run tests in a clean directory
+      run: |
+        mkdir testdir
+        cd testdir
+        python -m unittest discover -v ibm2ieee
+
+jobs:
+  test-sdist:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-architecture: [x86, x64]
+        exclude:
+        - os: macos-latest
+          python-architecture: x86
+        - os: ubuntu-latest
+          python-architecture: x86
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+    - name: Install prerequisites
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install wheel
+    - name: Install from PyPI sdist
+      run: |
+        python -m pip install --no-binary ibm2ieee ibm2ieee
     - name: Run tests in a clean directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -1,0 +1,37 @@
+name: Test installation from PyPI
+
+on:
+  pull_request
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-architecture: [x86, x64]
+        exclude:
+        - os: macos-latest
+          python-architecture: x86
+        - os: ubuntu-latest
+          python-architecture: x86
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+    - name: Install prerequisites
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install wheel
+    - name: Install the package
+        python -m pip install ibm2ieee
+    - name: Run tests in a clean directory
+      run: |
+        mkdir testdir
+        cd testdir
+        python -m unittest discover -v ibm2ieee

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install wheel
     - name: Install wheel from PyPI
       run: |
-        python -m pip install --only-binary ibm2ieee
+        python -m pip install --only-binary :all: ibm2ieee
     - name: Run tests in a clean directory
       run: |
         mkdir testdir


### PR DESCRIPTION
This PR adds a workflow to install ibm2ieee directly from PyPI wheels and run the test suite for that installed version.

~Before merging, we'll change the workflow trigger to turn it into a cron job running weekly.~ Done, except that we're running twice monthly instead of weekly. That's probably enough.