### PR TITLE
Update build and distribution infrastructure

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -20,21 +20,19 @@ jobs:
 
     steps:
     - name: Check out the commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
     - name: Install prerequisites
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install wheel
+        python -m pip install --upgrade pip
         python -m pip install flake8 flake8-ets
         python -m pip install .
     - name: Run style check
-      run: |
-        python -m flake8
+      run: python -m flake8
     - name: Run tests
       run: |
         mkdir testdir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = [
-    # pin NumPy version used in the build, to avoid building against the latest
-    # NumPy from PyPI (and potentially introducing ABI compatibilities with the
-    # actual NumPy version in the environment)
-    "numpy>=1.14,<1.15; python_version<'3.9'",
-    "numpy>=1.16,<1.17; python_version=='3.9'",
-    # don't pin version for as-yet-unreleased versions of Python
-    "numpy>=1.16; python_version>'3.9'",
-    "setuptools",
-    "wheel",
-]
+requires = ['oldest-supported-numpy', 'setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'
+
+[tool.black]
+line-length = 79
+target-version = ['py36']
+
+[tool.isort]
+profile = 'black'
+line-length = 79
+order_by_type = 'False'

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-from __future__ import absolute_import, print_function
-
 import os
 
 import numpy
@@ -34,12 +32,8 @@ def get_long_description():
 
 ibm2ieee_extension = setuptools.Extension(
     name="ibm2ieee._ibm2ieee",
-    sources=[
-        "ibm2ieee/_ibm2ieee.c",
-    ],
-    define_macros=[
-        ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-    ],
+    sources=["ibm2ieee/_ibm2ieee.c"],
+    define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
     include_dirs=[numpy.get_include()],
 )
 
@@ -59,10 +53,7 @@ if __name__ == "__main__":
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
         keywords="ibm hfp ieee754 hexadecimal floating-point ufunc",
-        install_requires=[
-            "numpy>=1.14; python_version<'3.9'",
-            "numpy>=1.16; python_version>='3.9'",
-        ],
+        install_requires=["numpy"],
         extras_require={
             "test": ["setuptools"],
         },
@@ -79,5 +70,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
     )


### PR DESCRIPTION
This PR:

- Adds Python 3.10 and 3.11 to the test matrix
- Updates action versions in the test workflow
- Updates `pyproject.toml` to use `latest-supported-numpy`; with this, we drop the version requirement on the runtime version of NumPy
- Also adds isort and black configs to pyproject.toml
- Adds Python 3.10 and 3.11 to the trove classifiers
- Does some other drive-by stylistic cleanup.