### PR TITLE
Test PyPI wheels and sdists on 3.10 and 3.11

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -22,14 +22,13 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
     - name: Install prerequisites
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install wheel
+        python -m pip install --upgrade pip
     - name: Install wheel from PyPI
       run: |
         python -m pip install --only-binary :all: ibm2ieee
@@ -43,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -55,14 +54,13 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
     - name: Install prerequisites
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install wheel
+        python -m pip install --upgrade pip
     - name: Install from PyPI sdist
       run: |
         python -m pip install --no-binary ibm2ieee ibm2ieee


### PR DESCRIPTION
This PR updates the test-from-pypi workflow to include Python 3.10 and 3.11 in the tests, and makes some drive-by cleanups and updates to the workflow in passing.