### PR TITLE
Apply black and isort, and enforce style in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,10 +29,13 @@ jobs:
     - name: Install prerequisites
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 flake8-ets
+        python -m pip install black flake8 flake8-ets isort
         python -m pip install .
-    - name: Run style check
-      run: python -m flake8
+    - name: Run style checks
+      run: |
+        python -m isort --check .
+        python -m black --check .
+        python -m flake8
     - name: Run tests
       run: |
         mkdir testdir

--- a/ibm2ieee/__init__.py
+++ b/ibm2ieee/__init__.py
@@ -8,10 +8,11 @@
 #
 # Thanks for using Enthought open source!
 
-from .version import version as __version__
 from ._ibm2ieee import ibm2float32, ibm2float64
-
+from .version import version as __version__
 
 __all__ = [
-    "__version__", "ibm2float32", "ibm2float64",
+    "__version__",
+    "ibm2float32",
+    "ibm2float64",
 ]

--- a/ibm2ieee/test/test_ibm2ieee.py
+++ b/ibm2ieee/test/test_ibm2ieee.py
@@ -9,10 +9,10 @@
 # Thanks for using Enthought open source!
 
 import contextlib
-from fractions import Fraction as F
 import io
 import itertools
 import unittest
+from fractions import Fraction as F
 
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,5 @@ target-version = ['py36']
 
 [tool.isort]
 profile = 'black'
-line-length = 79
+line_length = 79
 order_by_type = 'False'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 
 
 def get_version_info():
-    """ Extract version information as a dictionary from version.py. """
+    """Extract version information as a dictionary from version.py."""
     version_info = {}
     version_filename = os.path.join("ibm2ieee", "version.py")
     with open(version_filename, "r", encoding="utf-8") as version_module:
@@ -25,7 +25,7 @@ def get_version_info():
 
 
 def get_long_description():
-    """ Read long description from README.txt. """
+    """Read long description from README.txt."""
     with open("README.rst", "r", encoding="utf-8") as readme:
         return readme.read()
 


### PR DESCRIPTION
This PR applies `black` and `isort` to the codebase, and enforces style checks in CI. It also fixes an error in the isort config.