### PR TITLE
Prepare for release of version 1.2.0 of ibm2ieee

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,28 @@
 Changelog for ibm2ieee
 ======================
 
+Release 1.2.0
+-------------
+
+Release date: 2022-08-16
+
+This minor release updates supported Python versions and various parts of the
+continuous integration and development workflow. There are no changes to the
+functional core.
+
+- Apply black and isort to the code, and enforce style in CI checks. (#33)
+- Extend wheel and sdist tests to include Python 3.10 and Python 3.11. (#32,
+  #34)
+- Update PyPI wheel-build-and-upload workflow to use cibuildwheel. (#31)
+- Update .gitignore. (#29)
+- Use subTest in repetitive tests. (#27)
+- Update build infrastructure; use ``oldest-supported-numpy`` in build
+  requirements; extend to Python 3.10 and 3.11. (#30)
+- Update copyright end year. (#28)
+- Update installation notes to mention wheels. (#24)
+- Add workflow to test PyPI wheels. (#23)
+
+
 Release 1.1.0
 -------------
 

--- a/ibm2ieee/version.py
+++ b/ibm2ieee/version.py
@@ -9,4 +9,4 @@
 # Thanks for using Enthought open source!
 
 # Version string.
-version = "1.1.0"
+version = "1.2.0"


### PR DESCRIPTION
This PR updates the changelog and bumps the version in preparation for the 1.2.0 release of ibm2ieee.

I wavered over whether to go with a bugfix release number or a minor feature release. The support for new Python versions feels feature-y, though, and there aren't any actual bugfixes in this release.