### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,6 @@
 name: Run tests
 
-on:
-  pull_request
+on: [pull_request, workflow_dispatch]
 
 jobs:
   test:
@@ -26,17 +25,18 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
+        cache: 'pip'
+        cache-dependency-path: '.github/workflows/test-requirements.txt'
     - name: Install prerequisites
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install black flake8 flake8-ets isort
-        python -m pip install .
+      run: python -m pip install -r .github/workflows/test-requirements.txt
+    - name: Install the package
+      run: python -m pip install .
     - name: Run style checks
       run: |
         python -m isort --check .
         python -m black --check .
         python -m flake8
-    - name: Run tests
+    - name: Run tests from a clean directory
       run: |
         mkdir testdir
         cd testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -27,9 +27,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
-    - name: Install prerequisites
-      run: |
-        python -m pip install --upgrade pip
     - name: Install wheel from PyPI
       run: |
         python -m pip install --only-binary :all: ibm2ieee
@@ -59,9 +56,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
-    - name: Install prerequisites
-      run: |
-        python -m pip install --upgrade pip
     - name: Install from PyPI sdist
       run: |
         python -m pip install --no-binary ibm2ieee ibm2ieee

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -1,6 +1,7 @@
 name: Test installation from PyPI
 
 on:
+  workflow_dispatch:
   schedule:
     # Run at 02:37 UTC on the 11th and 25th of every month
     - cron: '37 2 11,25 * *'

--- a/.github/workflows/test-requirements.txt
+++ b/.github/workflows/test-requirements.txt
@@ -1,0 +1,4 @@
+black
+flake8
+flake8-ets
+isort

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -38,10 +38,10 @@ jobs:
     - name: Check and upload wheels
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        # TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict wheelhouse/*.whl
-        # python -m twine upload wheelhouse/*.whl
+        python -m twine upload wheelhouse/*.whl
 
   build-sdist:
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
     - name: Publish sdist to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        # TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*
-        # python -m twine upload dist/*
+        python -m twine upload dist/*

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -41,7 +41,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict wheelhouse/*.whl
-        python -m twine upload wheelhouse/*.whl
+        python -m twine upload --skip-existing wheelhouse/*.whl
 
   build-sdist:
     runs-on: ubuntu-latest
@@ -68,4 +68,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*
-        python -m twine upload dist/*
+        python -m twine upload --skip-existing dist/*

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
         platforms: arm64
       if: runner.os == 'Linux'
@@ -30,16 +30,10 @@ jobs:
         python-version: '3.10'
 
     - name: Install Python packages needed for wheel build and upload
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install twine
+      run: python -m pip install twine
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.9.0
-      env:
-        CIBW_SKIP: 'pp*'
-        CIBW_ARCHS_LINUX: "auto aarch64"
-        CIBW_ARCHS_MACOS: "auto universal2"
 
     - name: Check and upload wheels
       env:
@@ -63,13 +57,10 @@ jobs:
         python-version: '3.10'
 
     - name: Install Python packages needed for sdist build and upload
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install build twine
+      run: python -m pip install build twine
 
     - name: Build sdist
-      run: |
-        python -m build --sdist
+      run: python -m build --sdist
 
     - name: Publish sdist to PyPI
       env:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -38,10 +38,10 @@ jobs:
     - name: Check and upload wheels
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        # TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict wheelhouse/*.whl
-        python -m twine upload wheelhouse/*.whl
+        # python -m twine upload wheelhouse/*.whl
 
   build-sdist:
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
     - name: Publish sdist to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        # TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*
-        python -m twine upload dist/*
+        # python -m twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,13 @@ target-version = ['py36']
 profile = 'black'
 line_length = 79
 order_by_type = 'False'
+
+[tool.cibuildwheel]
+skip = "pp* *-musllinux*"
+
+[tool.cibuildwheel.macos]
+archs = ["auto", "universal2"]
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]
+skip = "*-musllinux_*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,3 @@ archs = ["auto", "universal2"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
-skip = "*-musllinux_*"


### PR DESCRIPTION
This PR comprises several GitHub Actions workflow updates

- Update the wheel build to use pyproject.toml for its configuration
- Update the wheel build to not build musllinux wheels (these were being very slow to build, taking over an hour each)
- Update the test build to cache dependencies
- Add workflow dispatch triggers to both the test build and the test-from-pypi build
- Remove unnecessary pip upgrades
- Update setup-qemu-action to the latest version

TODO
- [ ] Undo the commenting out of the twine upload code
