### PR TITLE
Updates for 2023

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -33,7 +33,7 @@ jobs:
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.9.0
+      uses: pypa/cibuildwheel@v2.12.1
 
     - name: Check and upload wheels
       env:

--- a/CHANGES
+++ b/CHANGES
@@ -6,9 +6,11 @@ Release 1.3.0
 
 Release date: 2023-03-31
 
-This minor release updates supported Python versions and various parts of
-the CI workflow. There are no changes to the functional core. Python 3.7
-is no longer supported
+This minor release updates supported Python versions. There are no changes to
+the functional core.
+
+- Python 3.6 is no longer supported; the minimum required version is Python
+  3.7.
 
 Release 1.2.0
 -------------

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,15 @@
 Changelog for ibm2ieee
 ======================
 
+Release 1.3.0
+-------------
+
+Release date: 2023-03-31
+
+This minor release updates supported Python versions and various parts of
+the CI workflow. There are no changes to the functional core. Python 3.7
+is no longer supported
+
 Release 1.2.0
 -------------
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-(C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+(C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ ibm2ieee requires Python >= 3.7.
 License
 -------
 
-(C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+(C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 All rights reserved.
 
 This software is provided without warranty under the terms of the BSD

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ Wheels are provided for common platforms and Python versions. If installing
 from source, note that ibm2ieee includes a C extension, so you'll need the
 appropriate compiler on your system to be able to install.
 
-ibm2ieee requires Python >= 3.6.
+ibm2ieee requires Python >= 3.7.
 
 
 License

--- a/ibm2ieee/__init__.py
+++ b/ibm2ieee/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/ibm2ieee/_ibm2ieee.c
+++ b/ibm2ieee/_ibm2ieee.c
@@ -1,4 +1,4 @@
-// (C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+// (C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/ibm2ieee/test/__init__.py
+++ b/ibm2ieee/test/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/ibm2ieee/test/test_ibm2ieee.py
+++ b/ibm2ieee/test/test_ibm2ieee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/ibm2ieee/test/test_version.py
+++ b/ibm2ieee/test/test_version.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/ibm2ieee/version.py
+++ b/ibm2ieee/version.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/ibm2ieee/version.py
+++ b/ibm2ieee/version.py
@@ -9,4 +9,4 @@
 # Thanks for using Enthought open source!
 
 # Version string.
-version = "1.2.0"
+version = "1.3.0"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2022 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2023 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         extras_require={
             "test": ["setuptools"],
         },
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         packages=setuptools.find_packages(),
         ext_modules=[ibm2ieee_extension],
         classifiers=[
@@ -66,11 +66,5 @@ if __name__ == "__main__":
             "License :: OSI Approved :: BSD License",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
         ],
     )


### PR DESCRIPTION
It's time for the annual update of `ibm2ieee`

- Drop Python 3.6 support from CI workflows, since Python 3.6 is no longer available from the `setup-python` action on `ubuntu-latest`.
- Replace '3.11-dev' with '3.11' in CI workflows.
- Drop Python 3.6 support generally, since Python 3.6 is way beyond EOL at this point
- Update copyright headers
- Drop version-specific trove classifiers
- Bump version number, and update changelog
- Bump cibuildwheel version.

There are no changes to the core code.