### PR TITLE
Support Python 3.12; update other action and Python versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Check out the commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
       if: runner.os == 'Linux'
@@ -27,13 +27,13 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Python packages needed for wheel build and upload
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.1
+      uses: pypa/cibuildwheel@v2.16.2
 
     - name: Check and upload wheels
       env:
@@ -49,12 +49,12 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Python packages needed for sdist build and upload
       run: python -m pip install build twine

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,14 @@
 Changelog for ibm2ieee
 ======================
 
+Release 1.3.2
+-------------
+
+Release date: 2023-10-08
+
+This bugfix release extends the wheel building configuration to support
+Python 3.12.
+
 Release 1.3.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'ibm2ieee'
-version = '1.3.1'
+version = '1.3.2'
 description = 'Convert IBM hexadecimal floating-point to IEEE 754 floating-point'
 readme = 'README.rst'
 requires-python = ">=3.7"


### PR DESCRIPTION
This PR updates the cibuildwheel action versions to support building wheels for Python 3.12, and updates CI to run tests on Python 3.12. While we're doing this, we also update other actions to their latest versions.

Also updates the changelog and bumps the version number in preparation for a 1.3.2 bugfix release.