### PR TITLE
Fix wheel build

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -41,6 +41,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict wheelhouse/*.whl
+        python -m twine upload --skip-existing wheelhouse/*.whl
 
   build-sdist:
     runs-on: ubuntu-latest
@@ -67,3 +68,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*
+        python -m twine upload --skip-existing dist/*

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -41,7 +41,6 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict wheelhouse/*.whl
-        python -m twine upload --skip-existing wheelhouse/*.whl
 
   build-sdist:
     runs-on: ubuntu-latest
@@ -68,4 +67,3 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*
-        python -m twine upload --skip-existing dist/*

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,14 @@
 Changelog for ibm2ieee
 ======================
 
+Release 1.3.3
+-------------
+
+Release date: 2023-10-08
+
+This bugfix release fixes the wheel building configuration by removing
+support for cp312-manylinux_i686.
+
 Release 1.3.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ line_length = 79
 order_by_type = 'False'
 
 [tool.cibuildwheel]
-skip = "pp* *-musllinux*"
+skip = "pp* *-musllinux* cp312-manylinux_i686"
 
 [tool.cibuildwheel.macos]
 archs = ["auto", "universal2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'ibm2ieee'
-version = '1.3.2'
+version = '1.3.3'
 description = 'Convert IBM hexadecimal floating-point to IEEE 754 floating-point'
 readme = 'README.rst'
 requires-python = ">=3.7"


### PR DESCRIPTION
This PR attempts to fix the wheel build: we failed to build wheels for cp312-manylinux_i686 for the 1.3.2 release, I believe because the oldest supported numpy version for 3.12 no longer supports 32-bit Linux.